### PR TITLE
refactor: dependency injection, API key validation and config cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-# https://openweathermap.org/api
-API_KEY=""

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
   - [Configuring](#configuring)
-    - [.env](#env)
+    - [Environment Variables](#environment-variables)
   - [Building](#building)
   - [Running](#running)
     - [Linux and macOS](#linux-and-macos)
@@ -28,21 +28,43 @@ displays current temperature, feels like, humidity, wind speed and local time, a
 ## Requirements
 
 - Java 21+
-- Maven
+- Maven 3.9+
 
 ## Getting Started
 
 ### Configuring
 
-#### **.env**
+#### Environment Variables
 
-For this step, you'll need to generate your API key at [OpenWeatherMap](https://openweathermap.org/api) website.
+You'll need an API key from [OpenWeatherMap](https://openweathermap.org/api).
 
-Rename the `.env.example` file to `.env` and update the variable with your generated key.
+Set the `API_KEY` environment variable before running the application.
 
-| key     | description              | default |
-| ------- | ------------------------ | ------- |
-| API_KEY | OpenWeatherMap API key | -       |
+**Linux / macOS:**
+
+For the current session only:
+```bash
+export API_KEY=your-api-key
+```
+
+To persist, add to your `~/.bashrc` or `~/.zshrc` and reload:
+```bash
+export API_KEY=your-api-key
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+**Windows — Command Prompt:**
+```cmd
+set API_KEY=your-api-key
+```
+
+**Windows — PowerShell:**
+```powershell
+$env:API_KEY = "your-api-key"
+```
+
+> [!NOTE]
+> `set` and `$env:` are session-only on Windows. To persist, add via System Properties → Environment Variables.
 
 ### Building
 
@@ -60,28 +82,28 @@ This will create an executable JAR file at `target/weatherish.jar`.
 
 On Linux and macOS, you have several options to run the application:
 
-- Option 1: Direct JAR execution
+**Option 1: Direct JAR execution**
 
-  ```bash
-  java -jar target/weatherish.jar
-  ```
+```bash
+java -jar target/weatherish.jar
+```
 
-- Option 2: Using the wrapper script
-  > [!NOTE]
-  > First time only, make the script executable:
-  > ```bash
-  > chmod +x weatherish
-  > ```
+**Option 2: Using the wrapper script**
+> [!NOTE]
+> First time only, make the script executable:
+> ```bash
+> chmod +x weatherish
+> ```
 
-  ```bash
-  ./weatherish 
-  ```
+```bash
+./weatherish 
+```
 
-- Option 3: Create a system-wide alias by adding this to your `.bashrc` or `.zshrc`:
+**Option 3: Create a system-wide alias by adding this to your `.bashrc` or `.zshrc`:**
 
-  ```bash
-  alias weatherish='java -jar /full/path/to/weatherish/target/weatherish.jar'
-  ```
+```bash
+alias weatherish='java -jar /full/path/to/weatherish/target/weatherish.jar'
+```
 
 Then reload your profile (`source ~/.bashrc` or `source ~/.zshrc`) or restart your terminal.
 
@@ -91,14 +113,15 @@ Now you can use `weatherish` from anywhere in your terminal.
 
 For Windows environments, you can execute the application by choosing one of the following options:
 
-- Option 1: Using the wrapper script
-  ```bat
-  weatherish.bat 
-  ```
-- Option 2: Create a system-wide alias by adding this to your PowerShell profile:
-  ```powershell
-  function weatherish { java -jar "C:\full\path\to\weatherish\target\weatherish.jar" }
-  ```
+**Option 1: Using the wrapper script**
+```bat
+weatherish.bat 
+```
+
+**Option 2: Create a system-wide alias by adding this to your PowerShell profile:**
+```powershell
+function weatherish { java -jar "C:\full\path\to\weatherish\target\weatherish.jar" }
+```
 Then reload your profile (`. $PROFILE`) or restart your terminal.
 
 Now you can use `weatherish` from anywhere in your terminal.
@@ -106,7 +129,7 @@ Now you can use `weatherish` from anywhere in your terminal.
 
 ## Usage
 
-Run the application and enter the desired city when prompted. The CLI will display current weather information for that location.
+Run the application using preferred option and enter the desired city when prompted. The CLI will display current weather information for that location.
 
 ## Preview
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,18 +18,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<main.class>com.laporeon.weatherish.Weatherish</main.class>
 		<gson.version>2.11.0</gson.version>
-		<dotenv.version>3.2.0</dotenv.version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>${gson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.github.cdimascio</groupId>
-			<artifactId>dotenv-java</artifactId>
-			<version>${dotenv.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/laporeon/weatherish/Weatherish.java
+++ b/src/main/java/com/laporeon/weatherish/Weatherish.java
@@ -1,12 +1,19 @@
 package com.laporeon.weatherish;
 
+import com.google.gson.Gson;
 import com.laporeon.weatherish.application.CommandLineInterface;
+import com.laporeon.weatherish.client.WeatherClient;
+import com.laporeon.weatherish.helpers.Formatter;
+
+import java.net.http.HttpClient;
+import java.util.Scanner;
 
 public class Weatherish {
 
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args)  {
 
-		CommandLineInterface commandLineInterface = new CommandLineInterface();
+		WeatherClient client = new WeatherClient(new Gson(), HttpClient.newHttpClient());
+		CommandLineInterface commandLineInterface = new CommandLineInterface(new Scanner(System.in), new Formatter(), client);
 		commandLineInterface.start();
 		
 	}

--- a/src/main/java/com/laporeon/weatherish/application/CommandLineInterface.java
+++ b/src/main/java/com/laporeon/weatherish/application/CommandLineInterface.java
@@ -10,8 +10,15 @@ import java.util.Scanner;
 
 public class CommandLineInterface {
 
-    Scanner scanner = new Scanner(System.in);
-    Formatter formatter = new Formatter();
+    private final Scanner scanner;
+    private final Formatter formatter;
+    private final WeatherClient weatherClient;
+
+    public CommandLineInterface(Scanner scanner, Formatter formatter, WeatherClient weatherClient) {
+        this.scanner = scanner;
+        this.formatter = formatter;
+        this.weatherClient = weatherClient;
+    }
 
     public void start() {
         displayLogo();
@@ -22,9 +29,8 @@ public class CommandLineInterface {
         scanner.close();
 
         try {
-            Weather data = new WeatherClient().getData(city, unit);
+            Weather data = weatherClient.getData(city, unit);
             String formattedResponse = formatter.formatOutput(data, unit);
-
             System.out.printf("\n%s\n", formattedResponse);
         } catch (Exception ex) {
             System.out.printf("\n%s%s%s\n", Color.RED, ex.getMessage(), Color.RESET);

--- a/src/main/java/com/laporeon/weatherish/client/WeatherClient.java
+++ b/src/main/java/com/laporeon/weatherish/client/WeatherClient.java
@@ -2,8 +2,8 @@ package com.laporeon.weatherish.client;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.laporeon.weatherish.enums.Color;
 import com.laporeon.weatherish.models.Weather;
-import io.github.cdimascio.dotenv.Dotenv;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -13,29 +13,49 @@ import java.net.http.HttpResponse;
 public class WeatherClient {
 
     private static final String BASE_URL = "https://api.openweathermap.org/data/2.5";
-    private static final String API_KEY = Dotenv.load().get("API_KEY");
     private static final String ERROR_MESSAGE = "❌ Error %s: %s. Please check your input and try again.";
-    private static final Gson GSON = new Gson();
-    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    private final Gson gson;
+    private final HttpClient httpClient;
+    private final String apiKey;
+
+    public WeatherClient(Gson gson, HttpClient httpClient) {
+        this.gson = gson;
+        this.httpClient = httpClient;
+        this.apiKey = resolveApiKey();
+    }
 
     public Weather getData(String city, String unit) throws Exception {
-        String url = BASE_URL + "/weather?q=" + city + "&appid=" + API_KEY + "&units=" + unit;
+        // Only spaces need to be encoded as %20 to produce a valid URL
+        // as OpenWeatherMap API handles city name with accents.
+        String formattedCity = city.replace(" ", "%20");
+
+        String url = BASE_URL + "/weather?q=" + formattedCity + "&appid=" + apiKey + "&units=" + unit;
 
         HttpRequest request = HttpRequest.newBuilder()
                                          .uri(URI.create(url))
                                          .GET()
                                          .build();
 
-        HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
         if (response.statusCode() != 200) {
-            JsonObject error = GSON.fromJson(response.body(), JsonObject.class);
+            JsonObject error = gson.fromJson(response.body(), JsonObject.class);
             String status = error.get("cod").getAsString();
             String message =  error.get("message").getAsString();
             throw new RuntimeException(ERROR_MESSAGE.formatted(status, message));
         }
 
-        return GSON.fromJson(response.body(), Weather.class);
+        return gson.fromJson(response.body(), Weather.class);
+    }
+
+    private static String resolveApiKey() {
+        String key = System.getenv("API_KEY");
+        if (key == null || key.isBlank()) {
+            System.err.printf("%s❌ Error: API_KEY variable is not set.%s", Color.RED, Color.RESET);
+            System.exit(1);
+        }
+        return key;
     }
 
 }

--- a/weatherish
+++ b/weatherish
@@ -13,4 +13,4 @@ if [[ ! -f "$JAR_PATH" ]]; then
   exit 1
 fi
 
-exec "$JAVA_CMD" -jar "$JAR_PATH"
+exec "$JAVA_CMD" -Dfile.encoding=UTF-8 -jar "$JAR_PATH"


### PR DESCRIPTION
### What changed

- Removed `dotenv` dependency and `.env.example` file and replaced it with native `System.getenv()` method
- Added validation method to verify if `API_KEY` is set
- Injected `WeatherClient` into `CommandLineInterface` constructor instead of instantiating it internally
- Injected `Gson` and `HttpClient`  into `WeatherClient` constructor instead of instantiating it internally
- Fixed white spaces handling in cities name following external API encoding requirements
- Added file encoding declaration to bash wrapper script
- Updated README to reflect the new configuring and running instructions
